### PR TITLE
Feature/use loopring api to get nft data and metadata

### DIFF
--- a/Maize/Maize.csproj
+++ b/Maize/Maize.csproj
@@ -52,6 +52,9 @@
     <None Update="Input\Environment\mainnetappsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Input\Environment\MYmainnetappsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Input\Files\WannaCollab.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Maize/Models/NftCollectionItemsWithMetadata.cs
+++ b/Maize/Models/NftCollectionItemsWithMetadata.cs
@@ -1,0 +1,60 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Maize.Models
+{
+    public class Base
+    {
+        public string name { get; set; }
+        public int decimals { get; set; }
+        public string description { get; set; }
+        public string image { get; set; }
+        public string properties { get; set; }
+        public string localization { get; set; }
+        public long createdAt { get; set; }
+        public long updatedAt { get; set; }
+    }
+
+    public class Metadata
+    {
+        public string uri { get; set; }
+        [JsonProperty(PropertyName = "base")]
+        public Base basename { get; set; }
+        public int status { get; set; }
+        public int nftType { get; set; }
+        public int network { get; set; }
+        public string tokenAddress { get; set; }
+        public string nftId { get; set; }
+    }
+
+    public class NftTokenInfoItemWithMetadata
+    {
+        public string nftData { get; set; }
+        public string minter { get; set; }
+        public string nftType { get; set; }
+        public string tokenAddress { get; set; }
+        public string nftId { get; set; }
+        public int creatorFeeBips { get; set; }
+        public int royaltyPercentage { get; set; }
+        public int originalRoyaltyPercentage { get; set; }
+        public bool status { get; set; }
+        public string nftFactory { get; set; }
+        public string nftOwner { get; set; }
+        public string nftBaseUri { get; set; }
+        public string royaltyAddress { get; set; }
+        public string originalMinter { get; set; }
+        public long createdAt { get; set; }
+        public Metadata metadata { get; set; }
+        public int total { get; set; }
+    }
+
+    public class NftCollectionItemsWithMetadata
+    {
+        public int totalNum { get; set; }
+        public List<NftTokenInfoItemWithMetadata> nftTokenInfos { get; set; }
+    }
+}

--- a/Maize/Program.cs
+++ b/Maize/Program.cs
@@ -820,12 +820,12 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
             string option = "";
             do
             {
-                Console.WriteLine("Enter Option 1 or 2:", font);
+                Console.Write("Enter Option 1 or 2:", font);
                 option = Console.ReadLine();
             } while (option != "1" && option != "2");
             if(option == "1")
             {
-                font.ToPrimary("Retrieving collections...");
+                font.ToPrimary("Retrieving your collections...");
                 var userCollections = await loopringService.GetNftCollectionsOfOwnAccount(settings.LoopringApiKey, settings.LoopringAddress);
                 font.ToPrimary("Here are your collections.");
                 Dictionary<int, string> collectionsDictionary = new Dictionary<int, string>();
@@ -837,7 +837,21 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
                         collectionsDictionary.Add(collection.collection.id, collection.collection.name);
                     }
                 }
-                int collectionId = 0;
+
+                string collectionIdString = "";
+                do
+                {
+                    Console.Write($"Enter a valid Collection ID: ");
+                    var collectionIdInputString = Console.ReadLine();
+                    int collectionIdInt;
+                    bool collectionIdConversion = Int32.TryParse(collectionIdInputString, out collectionIdInt);
+                    if(collectionsDictionary.ContainsKey(collectionIdInt))
+                    {
+                        collectionIdString = collectionIdInt.ToString();
+                        Console.WriteLine($"Retrieving Nft Data for Collection: {collectionsDictionary[collectionIdInt]}...");
+                    }
+                } 
+                while (collectionIdString == "");
             }
             else if(option == "2")
             {

--- a/Maize/Program.cs
+++ b/Maize/Program.cs
@@ -834,7 +834,7 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
                     foreach (var collection in userCollection.collections)
                     {
                         Console.WriteLine($"Name: {collection.collection.name}, ID: {collection.collection.id}");
-                        //collectionsDictionary.Add(collection.collection.id, collection.collection.name);
+                        collectionsDictionary.Add(collection.collection.id, collection.collection.name);
                     }
                 }
                 int collectionId = 0;

--- a/Maize/Program.cs
+++ b/Maize/Program.cs
@@ -823,7 +823,18 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
                 Console.WriteLine("Enter Option 1 or 2:", font);
                 option = Console.ReadLine();
             } while (option != "1" && option != "2");
-            if(option == "2")
+            if(option == "1")
+            {
+                var userCollections = await loopringService.GetNftCollectionsOfOwnAccount(settings.LoopringApiKey, settings.LoopringAddress);
+                foreach (var userCollection in userCollections)
+                {
+                    foreach (var collection in userCollection.collections)
+                    {
+                        Console.WriteLine($"Collection Name: {collection.collection.name}, ID: {collection.collection.id}");
+                    }
+                }
+            }
+            else if(option == "2")
             {
                 do
                 {

--- a/Maize/Program.cs
+++ b/Maize/Program.cs
@@ -28,7 +28,7 @@ var environmentPath = "Input/Environment";
 var fileName = "Input.txt";
 var banishFile = "Banish.txt";
 
-string userEnvironment = $"./{environmentPath}/{net}appsettings.json";
+string userEnvironment = $"./{environmentPath}/MY{net}appsettings.json";
     Console.Title = $"Maize: read to succeed ({net})";
 Console.Clear();
 
@@ -101,6 +101,7 @@ AccountInformation userAccountInformation = new();
 string nftData;
 bool contains = false;
 var sw = new Stopwatch();
+List<NftData> nftDataList = new();
 
 var signedMessage = EDDSAHelper.EddsaSignUrl(
 loopringPrivateKey,
@@ -815,44 +816,56 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
             font.ToDarkGray("You will need the minter and collection address.");
             Console.WriteLine();
             font.ToWhite("Let's get started.");
+            font.ToTertiary("You can choose to gather this data with either Option 1: By API or Option 2: By IPFS");
+            string option = "";
             do
             {
-                minterAndCollection = UtilsLoopring.GetMinterAndCollection(font);
-                responseOnMinter = await loopringService.CheckForEthAddress(settings.LoopringApiKey, minterAndCollection.minter);
-                responseOnAccountId = await loopringService.GetUserAccountInformationFromOwner(responseOnMinter);
-            }
-            while (responseOnAccountId == null);
-            sw = Stopwatch.StartNew();
-            Console.WriteLine();
-            font.ToPrimary("Gathering information...");
-            var nftDataList = await loopringService.GetUserMintedNftsWithCollection(font, settings.LoopringApiKey, responseOnAccountId.accountId, minterAndCollection.TokenId);
-            font.ToTertiaryInline($"\r{minterAndCollection.minter} has {nftDataList.Count} mints in this Collection.");
-            counter = 0;
-            Console.WriteLine();
-            foreach (var nftDataSingle in nftDataList)
+                Console.WriteLine("Enter Option 1 or 2:", font);
+                option = Console.ReadLine();
+            } while (option != "1" && option != "2");
+            if(option == "2")
             {
-                nftMetadata = await Utils.GetNftMetadata(font, ethereumService, nftMetadataService, nftDataSingle.nftId, nftDataSingle.tokenAddress);
-                if (nftMetadata != null)
+                do
                 {
-                    Utils.ClearLine();
-                    font.ToTertiaryInline($"\rAdding Nft: {++counter}/{nftDataList.Count} {nftMetadata.name}");
-                    nftDataAndName.Add(new NftDataAndName
-                    {
-                        nftData = nftDataSingle.nftData,
-                        nftName = nftMetadata.name
-                    });
+                    minterAndCollection = UtilsLoopring.GetMinterAndCollection(font);
+                    responseOnMinter = await loopringService.CheckForEthAddress(settings.LoopringApiKey, minterAndCollection.minter);
+                    responseOnAccountId = await loopringService.GetUserAccountInformationFromOwner(responseOnMinter);
                 }
-            }
+                while (responseOnAccountId == null);
+                sw = Stopwatch.StartNew();
+                Console.WriteLine();
+                font.ToPrimary("Gathering information...");
+                nftDataList = await loopringService.GetUserMintedNftsWithCollection(font, settings.LoopringApiKey, responseOnAccountId.accountId, minterAndCollection.TokenId);
+                font.ToTertiaryInline($"\r{minterAndCollection.minter} has {nftDataList.Count} mints in this Collection.");
+                counter = 0;
+                Console.WriteLine();
+                foreach (var nftDataSingle in nftDataList)
+                {
+                    nftMetadata = await Utils.GetNftMetadata(font, ethereumService, nftMetadataService, nftDataSingle.nftId, nftDataSingle.tokenAddress);
+                    if (nftMetadata != null)
+                    {
+                        Utils.ClearLine();
+                        font.ToTertiaryInline($"\rAdding Nft: {++counter}/{nftDataList.Count} {nftMetadata.name}");
+                        nftDataAndName.Add(new NftDataAndName
+                        {
+                            nftData = nftDataSingle.nftData,
+                            nftName = nftMetadata.name
+                        });
+                    }
+                }
 
-            excelFileName = $"NftDataFromCollection_{DateTime.UtcNow:yyyy-MM-dd HH-mm-ss}.csv";
-            using (var writer = new StreamWriter($"./Output/{excelFileName}"))
-            using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
-            {
-                csv.WriteRecords(nftDataAndName);
+                excelFileName = $"NftDataFromCollection_{DateTime.UtcNow:yyyy-MM-dd HH-mm-ss}.csv";
+                using (var writer = new StreamWriter($"./Output/{excelFileName}"))
+                using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
+                {
+                    csv.WriteRecords(nftDataAndName);
+                }
+                sw.Stop();
+                Utils.FunctionalityProcessTime(sw, excelFileName, null, font);
+                break;
             }
-            sw.Stop();
-            Utils.FunctionalityProcessTime(sw, excelFileName, null, font);
             break;
+
         #endregion case 6
         #region case 7
         case "7":

--- a/Maize/Program.cs
+++ b/Maize/Program.cs
@@ -825,12 +825,14 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
             } while (option != "1" && option != "2");
             if(option == "1")
             {
+                font.ToPrimary("Retrieving collections...");
                 var userCollections = await loopringService.GetNftCollectionsOfOwnAccount(settings.LoopringApiKey, settings.LoopringAddress);
+                font.ToPrimary("Here are your collections.");
                 foreach (var userCollection in userCollections)
                 {
                     foreach (var collection in userCollection.collections)
                     {
-                        Console.WriteLine($"Collection Name: {collection.collection.name}, ID: {collection.collection.id}");
+                        Console.WriteLine($"Name: {collection.collection.name}, ID: {collection.collection.id}");
                     }
                 }
             }

--- a/Maize/Program.cs
+++ b/Maize/Program.cs
@@ -28,7 +28,7 @@ var environmentPath = "Input/Environment";
 var fileName = "Input.txt";
 var banishFile = "Banish.txt";
 
-string userEnvironment = $"./{environmentPath}/MY{net}appsettings.json";
+string userEnvironment = $"./{environmentPath}/{net}appsettings.json";
     Console.Title = $"Maize: read to succeed ({net})";
 Console.Clear();
 
@@ -855,7 +855,6 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
                 sw = Stopwatch.StartNew();
                 Console.WriteLine($"Retrieving Nft Data for Collection: {collectionsDictionary[Int32.Parse(collectionIdString)]}...");
                 var nftsInCollection = await loopringService.GetNftCollectionItemsOfOwnAccount(settings.LoopringApiKey, collectionIdString);         
-                font.ToTertiaryInline($"\rYou have {nftsInCollection[0].totalNum} NFTs in this Collection.");
                 counter = 0;
                 Console.WriteLine();
                 foreach (var nftCollectionList in nftsInCollection)

--- a/Maize/Program.cs
+++ b/Maize/Program.cs
@@ -828,13 +828,16 @@ while (userResponseReadyToMoveOn == "yes" || userResponseReadyToMoveOn == "y")
                 font.ToPrimary("Retrieving collections...");
                 var userCollections = await loopringService.GetNftCollectionsOfOwnAccount(settings.LoopringApiKey, settings.LoopringAddress);
                 font.ToPrimary("Here are your collections.");
+                Dictionary<int, string> collectionsDictionary = new Dictionary<int, string>();
                 foreach (var userCollection in userCollections)
                 {
                     foreach (var collection in userCollection.collections)
                     {
                         Console.WriteLine($"Name: {collection.collection.name}, ID: {collection.collection.id}");
+                        //collectionsDictionary.Add(collection.collection.id, collection.collection.name);
                     }
                 }
+                int collectionId = 0;
             }
             else if(option == "2")
             {

--- a/Maize/Services/ILoopringService.cs
+++ b/Maize/Services/ILoopringService.cs
@@ -203,5 +203,7 @@ namespace Maize
             );
 
         Task<List<UserCollections>> GetNftCollectionsOfOwnAccount(string apiKey, string owner);
+
+        Task<List<NftCollectionItemsWithMetadata>> GetNftCollectionItemsOfOwnAccount(string apiKey, string collectionId);
     }
 }

--- a/Maize/Services/ILoopringService.cs
+++ b/Maize/Services/ILoopringService.cs
@@ -201,5 +201,7 @@ namespace Maize
             decimal lcrTransactionFee,
             string transferMemo
             );
+
+        Task<List<UserCollections>> GetNftCollectionsOfOwnAccount(string apiKey, string owner);
     }
 }

--- a/Maize/Services/LoopringService.cs
+++ b/Maize/Services/LoopringService.cs
@@ -2297,7 +2297,7 @@ namespace Maize
                 if (data.nftTokenInfos.Count != 0)
                 {
                     collections.Add(data);
-                    Console.WriteLine($"{offset}/{data.totalNum} retrieved...");
+                    Console.WriteLine($"{collections.Sum(x=> x.nftTokenInfos.Count)}/{data.totalNum} retrieved...");
                 }
                 while (data.nftTokenInfos.Count != 0)
                 {
@@ -2308,7 +2308,7 @@ namespace Maize
                     if (data.nftTokenInfos.Count != 0)
                     {
                         collections.Add(data);
-                        Console.WriteLine($"{offset}/{data.totalNum} retrieved...");
+                        Console.WriteLine($"{collections.Sum(x => x.nftTokenInfos.Count)}/{data.totalNum} retrieved...");
                     }
                 }
                 return collections;

--- a/Maize/Services/LoopringService.cs
+++ b/Maize/Services/LoopringService.cs
@@ -171,7 +171,7 @@ namespace Maize
         public async Task<List<UserCollections>> GetNftCollectionsOfOwnAccount(string apiKey, string owner)
         {
             List<UserCollections> collections = new List<UserCollections>();
-            var request = new RestRequest("/api/v3/nft/public/collection");
+            var request = new RestRequest("/api/v3/nft/collection");
             int offset = 0;
             request.AddHeader("x-api-key", apiKey);
             request.AddParameter("owner", owner);
@@ -181,11 +181,11 @@ namespace Maize
             {
                 var response = await _client.GetAsync(request);
                 var data = JsonConvert.DeserializeObject<UserCollections>(response.Content!);
-                while (data != null)
+                while (data.collections.Count != 0)
                 {
                     response = await _client.GetAsync(request);
                     data = JsonConvert.DeserializeObject<UserCollections>(response.Content!);
-                    if (data != null)
+                    if (data.collections.Count != 0)
                     {
                         collections.Add(data);
                     }

--- a/Maize/Services/LoopringService.cs
+++ b/Maize/Services/LoopringService.cs
@@ -181,16 +181,20 @@ namespace Maize
             {
                 var response = await _client.GetAsync(request);
                 var data = JsonConvert.DeserializeObject<UserCollections>(response.Content!);
+                if (data.collections.Count != 0)
+                {
+                    collections.Add(data);
+                }
                 while (data.collections.Count != 0)
                 {
+                    offset += 12;
+                    request.AddOrUpdateParameter("offset", offset);
                     response = await _client.GetAsync(request);
                     data = JsonConvert.DeserializeObject<UserCollections>(response.Content!);
                     if (data.collections.Count != 0)
                     {
                         collections.Add(data);
                     }
-                    request.AddOrUpdateParameter("offset", offset);
-                    offset += 12;
                 }
                 return collections;
             }

--- a/Maize/Services/LoopringService.cs
+++ b/Maize/Services/LoopringService.cs
@@ -167,6 +167,39 @@ namespace Maize
                 return null;
             }
         }
+
+        public async Task<List<UserCollections>> GetNftCollectionsOfOwnAccount(string apiKey, string owner)
+        {
+            List<UserCollections> collections = new List<UserCollections>();
+            var request = new RestRequest("/api/v3/nft/public/collection");
+            int offset = 0;
+            request.AddHeader("x-api-key", apiKey);
+            request.AddParameter("owner", owner);
+            request.AddParameter("limit", 12);
+            request.AddParameter("offset", offset);
+            try
+            {
+                var response = await _client.GetAsync(request);
+                var data = JsonConvert.DeserializeObject<UserCollections>(response.Content!);
+                while (data != null)
+                {
+                    response = await _client.GetAsync(request);
+                    data = JsonConvert.DeserializeObject<UserCollections>(response.Content!);
+                    if (data != null)
+                    {
+                        collections.Add(data);
+                    }
+                    request.AddOrUpdateParameter("offset", offset);
+                    offset += 12;
+                }
+                return collections;
+            }
+            catch (HttpRequestException httpException)
+            {
+                _font.ToWhite($"Error getting collection: {httpException.Message}");
+                return null;
+            }
+        }
         public async Task<CollectionInformation> GetNftCollectionInformation(string apiKey, string id)
         {
             var request = new RestRequest("/api/v3/nft/public/collection/items");

--- a/Maize/Services/LoopringService.cs
+++ b/Maize/Services/LoopringService.cs
@@ -2280,6 +2280,44 @@ namespace Maize
             GC.SuppressFinalize(this);
         }
 
-
+        public async Task<List<NftCollectionItemsWithMetadata>> GetNftCollectionItemsOfOwnAccount(string apiKey, string collectionId)
+        {
+            List<NftCollectionItemsWithMetadata> collections = new List<NftCollectionItemsWithMetadata>();
+            var request = new RestRequest("/api/v3/nft/public/collection/items");
+            int offset = 0;
+            request.AddHeader("x-api-key", apiKey);
+            request.AddParameter("id", Int32.Parse(collectionId));
+            request.AddParameter("metadata", "true");
+            request.AddParameter("limit", 50);
+            request.AddParameter("offset", offset);
+            try
+            {
+                var response = await _client.GetAsync(request);
+                var data = JsonConvert.DeserializeObject<NftCollectionItemsWithMetadata>(response.Content!);
+                if (data.nftTokenInfos.Count != 0)
+                {
+                    collections.Add(data);
+                    Console.WriteLine($"{offset}/{data.totalNum} retrieved...");
+                }
+                while (data.nftTokenInfos.Count != 0)
+                {
+                    offset += 50;
+                    request.AddOrUpdateParameter("offset", offset);
+                    response = await _client.GetAsync(request);
+                    data = JsonConvert.DeserializeObject<NftCollectionItemsWithMetadata>(response.Content!);
+                    if (data.nftTokenInfos.Count != 0)
+                    {
+                        collections.Add(data);
+                        Console.WriteLine($"{offset}/{data.totalNum} retrieved...");
+                    }
+                }
+                return collections;
+            }
+            catch (HttpRequestException httpException)
+            {
+                _font.ToWhite($"Error getting collection items: {httpException.Message}");
+                return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
This is to fix #1. I've added a sub option to option 6(Find Nft Data from a collection). This PR splits option 6 into two options. 

- Option 1 - Get NFT metadata and nftData via the API
- Option 2 - Get NFT metadata and nftData via Infura & IPFS (Should work the same as before)

If option 1 is selected it will retrieve a list of collections you've minted: 

![image](https://user-images.githubusercontent.com/5258063/228181761-0229bb54-c570-4488-a2a7-1c90413c1635.png)

Then you need to choose the collection id and it will then start retrieving the data and generates the CSV:

![image](https://user-images.githubusercontent.com/5258063/228182131-4e165d74-0561-4403-8644-bf4ce5bdc576.png)

A 1000 item collection only takes 20 seconds on my slow ass Australian internet! If the nft name can not be found then I just made it default to "Name could not be retrieved..."